### PR TITLE
Bug fixes

### DIFF
--- a/adcommon/creds.py
+++ b/adcommon/creds.py
@@ -182,10 +182,13 @@ class YCreds:
                             self.__delete_keyring()
                     self.creds.set_username(user)
                     self.creds.set_password(password)
+                    if dom:
+                        self.creds.set_domain(dom)
                     return True
                 if str(subret) == 'krb_select':
                     user = UI.QueryWidget('krb_select', 'Label')[1:]
                     self.creds.set_username(user)
+                    self.creds.set_domain(UI.QueryWidget('krb_realm', 'Value'))
                     self.__validate_kinit()
                     if self.creds.get_kerberos_state() == MUST_USE_KERBEROS:
                         UI.CloseDialog()
@@ -278,7 +281,10 @@ class YCreds:
                     krb_selection = Frame('', VBox(
                         VSpacing(.5),
                         Left(PushButton(Id('krb_select'), Opt('hstretch', 'vstretch'), krb_user)),
-                        Left(Label(b'Domain: %s' % krb_realm))
+                        HBox(
+                            HWeight(1, Left(Label('Domain:'))),
+                            HWeight(4, Left(Label(Id('krb_realm'), Opt('hstretch'), krb_realm))),
+                        ),
                     ))
                 elif krb_user and krb_expired:
                     user = krb_user

--- a/adcommon/creds.py
+++ b/adcommon/creds.py
@@ -173,8 +173,6 @@ class YCreds:
                     if self.possible_save_creds:
                         save = UI.QueryWidget('remember_prompt', 'Value')
                     UI.CloseDialog()
-                    if not password:
-                        return False
                     if self.possible_save_creds:
                         if save:
                             self.__set_keyring(user, dom, password)
@@ -290,7 +288,7 @@ class YCreds:
                     user = krb_user
         return MinWidth(30, HBox(HSpacing(1), VBox(
             VSpacing(.5),
-            Left(Label('To continue, type an administrator password')),
+            Left(Label('To continue, type an Active Directory administrator password')),
             Frame('', VBox(
                 Left(TextEntry(Id('username_prompt'), Opt('hstretch', 'notify'), 'Username', user)),
                 Left(Password(Id('password_prompt'), Opt('hstretch'), 'Password', password)),

--- a/package/yast2-adcommon-python.changes
+++ b/package/yast2-adcommon-python.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Jun 17 19:23:59 UTC 2019 - dmulder@suse.com
+
+- Pass the domain name to the samba Credentials object; (bsc#1138487);
+- YaST aduc/adsi/gpmc should not exit after entering empty password.
+  Also, explicitly state that an Active Directory administrator should
+  sign in; (bsc#1132565);
+- 0.7
+
+-------------------------------------------------------------------
 Thu Jun 13 19:33:00 UTC 2019 - dmulder@suse.com
 
 - Move schema parsing code from adsi to the common code; (bsc#1138203);

--- a/package/yast2-adcommon-python.spec
+++ b/package/yast2-adcommon-python.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-adcommon-python
-Version:        0.6
+Version:        0.7
 Release:        0
 Summary:        Common code for the yast python ad modules
 License:        GPL-3.0+


### PR DESCRIPTION
- Pass the domain name to the samba Credentials object; (bsc#1138487);
- YaST aduc/adsi/gpmc should not exit after entering empty password.
  Also, explicitly state that an Active Directory administrator should
  sign in; (bsc#1132565);