### PR TITLE
 Use samba's SamDB interface for ldap connection

### DIFF
--- a/adcommon/creds.py
+++ b/adcommon/creds.py
@@ -203,6 +203,10 @@ class YCreds:
 
     def __validate_kinit(self):
         out, _ = Popen(['klist'], stdout=PIPE, stderr=PIPE).communicate()
+        m = re.findall(six.b('Ticket cache:\s*(.*)'), out)
+        if len(m) != 1:
+            return None
+        self.creds.set_named_ccache(m[0].decode())
         m = re.findall(six.b('Default principal:\s*(\w+)@([\w\.]+)'), out)
         if len(m) == 0:
             return None

--- a/adcommon/yldap.py
+++ b/adcommon/yldap.py
@@ -8,6 +8,7 @@ from yast import UI
 from samba.credentials import MUST_USE_KERBEROS
 from adcommon.creds import kinit_for_gssapi, krb5_temp_conf, pdc_dns_name
 from adcommon.strings import strcmp
+from samba.net import Net
 import os
 import six
 import ldapurl
@@ -86,6 +87,7 @@ class Ldap(samdb.SamDB):
         self.realm_dn = ','.join(['DC=%s' % part for part in self.realm.lower().split('.')])
         self.ldap_url = ldapurl.LDAPUrl(ldap_url) if ldap_url else None
         self.__ldap_connect()
+        self.net = Net(creds=self.creds, lp=self.lp)
         self.schema = {}
         self.__load_schema()
 

--- a/adcommon/yldap.py
+++ b/adcommon/yldap.py
@@ -87,6 +87,9 @@ class Ldap(samdb.SamDB):
         self.realm_dn = ','.join(['DC=%s' % part for part in self.realm.lower().split('.')])
         self.ldap_url = ldapurl.LDAPUrl(ldap_url) if ldap_url else None
         self.__ldap_connect()
+        # Ugly Hack: Make the ldap module backwards compatible with modules that
+        # called functions of l (the python ldap code).
+        self.l = self
         self.net = Net(creds=self.creds, lp=self.lp)
         self.schema = {}
         self.__load_schema()
@@ -160,6 +163,9 @@ class Ldap(samdb.SamDB):
         except Exception as e:
             ycpbuiltins.y2error(traceback.format_exc())
             ycpbuiltins.y2error('ldap.delete_s: %s\n' % self.__ldap_exc_msg(e))
+
+    def rename_s(self, dn, newrdn, newsuperior):
+        super(Ldap, self).rename(dn, '%s,%s' % (newrdn, newsuperior))
 
     def __find_inferior_classes(self, name):
         dn = self.get_schema_basedn()

--- a/package/yast2-adcommon-python.changes
+++ b/package/yast2-adcommon-python.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 22 15:55:34 UTC 2019 - dmulder@suse.com
+
+- AD modules should connect to an AD-DC via the SamDB interface,
+  instead of python-ldap; (bsc#1146898);
+- 1.0
+
+-------------------------------------------------------------------
 Tue Aug 13 19:57:54 UTC 2019 - dmulder@suse.com
 
 - Fix incorrectly placed domain in change domain dialog; (bsc#1145508);

--- a/package/yast2-adcommon-python.spec
+++ b/package/yast2-adcommon-python.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-adcommon-python
-Version:        0.8
+Version:        1.0
 Release:        0
 Summary:        Common code for the yast python ad modules
 License:        GPL-3.0+
@@ -30,7 +30,7 @@ Requires:       samba-client
 Requires:       samba-python3
 Requires:       yast2
 Requires:       yast2-python3-bindings >= 4.0.0
-Requires:       python3-ldap
+Requires:       python3-ldb
 Requires:       python3-keyring
 BuildRequires:	python3
 BuildRequires:	python3-setuptools


### PR DESCRIPTION
Use SamDB instead of relying on the python-ldap module. This gives us a lot more pre-built AD
code, plus easy object creation, connection handling, etc.