### PR TITLE
Remove ad-dc dependency; (jsc#ECO-2527);

### DIFF
--- a/adcommon/yldap.py
+++ b/adcommon/yldap.py
@@ -1,4 +1,4 @@
-from samba import samdb
+from samba import Ldb
 from samba.auth import system_session
 from samba import ldb
 import traceback
@@ -79,7 +79,7 @@ def stringify_ldap(data):
     else:
         return data
 
-class Ldap(samdb.SamDB):
+class Ldap(Ldb):
     def __init__(self, lp, creds, ldap_url=None):
         self.lp = lp
         self.creds = creds

--- a/package/yast2-adcommon-python.changes
+++ b/package/yast2-adcommon-python.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 07 15:12:29 UTC 2021 - dmulder@suse.com
+
+- Remove ad-dc dependency; (jsc#ECO-2527);
+- 1.6
+
+-------------------------------------------------------------------
 Mon Sep 28 11:10:58 UTC 2020 - dmulder@suse.com
 
 - Rev version for SLE update; (jsc#ECO-2527);

--- a/package/yast2-adcommon-python.spec
+++ b/package/yast2-adcommon-python.spec
@@ -17,18 +17,17 @@
 
 
 Name:           yast2-adcommon-python
-Version:        1.5
+Version:        1.6
 Release:        0
 Summary:        Common code for the yast python ad modules
 License:        GPL-3.0+
 Group:          Productivity/Networking/Samba
-Url:            https://github.com/dmulder/yast2-adcommon-python
+Url:            https://github.com/yast/yast2-adcommon-python
 Source:         %{name}-%{version}.tar.bz2
 BuildArch:      noarch
 Requires:       krb5-client
 Requires:       samba-client
 Requires:       samba-python3
-Requires:       samba-ad-dc
 Requires:       yast2
 Requires:       yast2-python3-bindings >= 4.0.0
 Requires:       python3-ldb


### PR DESCRIPTION
The ad-dc dependency needs to be removed in order to be supported in SLE. This dependency wasn't strictly necessary, as long as we use inherit from Ldb instead of SamDB (which is a child class of Ldb, and we weren't using the extra features in SamDB anyhow).